### PR TITLE
Fix: ibm-mq stub now correctly handles TLS option

### DIFF
--- a/bundles/ibm-mq/stub.go
+++ b/bundles/ibm-mq/stub.go
@@ -17,6 +17,7 @@ type CommonMQConfig struct {
 	UserId           string
 	Password         string
 	ApplicationName  string
+	TLS              *TLSConfig
 }
 
 // OutputConfig stub for non-mqclient builds
@@ -47,7 +48,6 @@ type InputConfig struct {
 // SystemConfig stub for non-mqclient builds
 type SystemConfig struct {
 	CommonMQConfig
-	TLS *TLSConfig
 }
 
 // TLSConfig stub for non-mqclient builds


### PR DESCRIPTION
- `ibm-mq` stub implementation now in line with the full implementation (https://github.com/wombatwisdom/components/blob/2c550556e5bf176be380d6ddabfe0173509d319b/bundles/ibm-mq/config.go#L28)
- unblocks https://github.com/wombatwisdom/wombat/pull/163 and https://github.com/wombatwisdom/wombat/pull/163